### PR TITLE
Add handing for Log4Net Thread Context stacks

### DIFF
--- a/Src/StackifyLib.log4net.v1_2_10/StackifyAppender.cs
+++ b/Src/StackifyLib.log4net.v1_2_10/StackifyAppender.cs
@@ -316,7 +316,19 @@ namespace StackifyLib.log4net
 
                 if (mdcValue != null)
                 {
-                    properties[mdcKey.ToLower()] = mdcValue;
+                    // Check if the property is a Log4net Context Stack,
+                    // If it is, then we want to read it as a string as that is
+                    // the expected behavior for a Log4Net Appender.
+                    var tcs = mdcValue as Apache_log4net.Util.ThreadContextStack;
+                    if (tcs != null)
+                    {
+                        properties[mdcKey.ToLower()] = tcs.ToString();
+                    }
+                    else
+                    {
+                        // for anything else, we will let Json.Net take care of it.
+                        properties[mdcKey.ToLower()] = mdcValue;
+                    }
                 }
             }
 
@@ -326,7 +338,19 @@ namespace StackifyLib.log4net
 
                 if (mdcValue != null)
                 {
-                    properties[mdcKey.ToLower()] = mdcValue;
+                    // Check if the property is a Log4net Context Stack,
+                    // If it is, then we want to read it as a string as that is
+                    // the expected behavior for a Log4Net Appender.
+                    var tcs = mdcValue as Apache_log4net.Util.ThreadContextStack;
+                    if (tcs != null)
+                    {
+                        properties[mdcKey.ToLower()] = tcs.ToString();
+                    }
+                    else
+                    {
+                        // for anything else, we will let Json.Net take care of it.
+                        properties[mdcKey.ToLower()] = mdcValue;
+                    }
                 }
             }
 

--- a/Src/StackifyLib.log4net/StackifyAppender.cs
+++ b/Src/StackifyLib.log4net/StackifyAppender.cs
@@ -307,7 +307,19 @@ namespace StackifyLib.log4net
 
                 if (mdcValue != null)
                 {
-                    properties[mdcKey.ToLower()] = mdcValue;
+                    // Check if the property is a Log4net Context Stack,
+                    // If it is, then we want to read it as a string as that is
+                    // the expected behavior for a Log4Net Appender.
+                    var tcs = mdcValue as Apache_log4net.Util.ThreadContextStack;
+                    if (tcs != null)
+                    {
+                        properties[mdcKey.ToLower()] = tcs.ToString();
+                    }
+                    else
+                    {
+                        // for anything else, we will let Json.Net take care of it.
+                        properties[mdcKey.ToLower()] = mdcValue;
+                    }
                 }
             }
 
@@ -317,7 +329,19 @@ namespace StackifyLib.log4net
 
                 if (mdcValue != null)
                 {
-                    properties[mdcKey.ToLower()] = mdcValue;
+                    // Check if the property is a Log4net Context Stack,
+                    // If it is, then we want to read it as a string as that is
+                    // the expected behavior for a Log4Net Appender.
+                    var tcs = mdcValue as Apache_log4net.Util.ThreadContextStack;
+                    if (tcs != null)
+                    {
+                        properties[mdcKey.ToLower()] = tcs.ToString();
+                    }
+                    else
+                    {
+                        // for anything else, we will let Json.Net take care of it.
+                        properties[mdcKey.ToLower()] = mdcValue;
+                    }
                 }
             }
             


### PR DESCRIPTION
When using Log4Net Context stacks, the value of the property send to Stackify would always be:
```{"Count":1}```

This fix will check if the property is a ThreadContextStack and read it correctly.