### PR TITLE
SF-6204: Limit the conditions where calls are made to a non-existent …

### DIFF
--- a/Src/StackifyLib/Config.cs
+++ b/Src/StackifyLib/Config.cs
@@ -74,7 +74,13 @@ namespace StackifyLib
                 {
                     ErrorSessionGoodKeys = CaptureErrorSessionWhitelist.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).ToList();
                 }
-	            
+
+                var isEc2 = Get("Stackify.IsEC2", "");
+                if (string.IsNullOrWhiteSpace(isEc2) == false)
+                {
+                    IsEc2 = isEc2.Equals("true", StringComparison.CurrentCultureIgnoreCase);
+                }
+
                 ApiHost = Get("Stackify.ApiHost", "https://api.stackify.net");
                 AuthTokenUrl = Get("Stackify.AuthTokenUrl", "https://auth.stackify.net/oauth2/token");
                 LogUri = Get("Stackify.LogUri", "api/v1/logs");
@@ -115,8 +121,10 @@ namespace StackifyLib
 
         public static string CaptureErrorCookiesBlacklist { get; set; } = ".ASPXAUTH";
 
+        public static bool? IsEc2 { get; set; } = null;
+
         /// <summary>
-        /// Global setting for any log appenders for how big the log queue size can be in memory 
+        /// Global setting for any log appenders for how big the log queue size can be in memory
         /// before messages are lost if there are problems uploading or we can't upload fast enough
         /// </summary>
         public static int MaxLogBufferSize { get; set; }  = 10000;

--- a/Src/StackifyLib/Internal/Auth/Claims/AppClaimsBuilderBase.cs
+++ b/Src/StackifyLib/Internal/Auth/Claims/AppClaimsBuilderBase.cs
@@ -25,6 +25,22 @@ namespace StackifyLib.Internal.Auth.Claims
             return AppClaims;
         }
 
+        protected async Task SetDeviceName()
+        {
+            var machineName = GetMachineName();
+
+            if (Config.IsEc2 == null || Config.IsEc2 == true || (machineName.StartsWith("EC2") && machineName.Contains("-")))
+            {
+                AppClaims.DeviceName = await GetEC2InstanceId() ?? machineName;
+            }
+            else
+            {
+                AppClaims.DeviceName = machineName;
+            }
+        }
+
         protected abstract Task BuildClaimsAsync();
+        protected abstract Task<string> GetEC2InstanceId();
+        protected abstract string GetMachineName();
     }
 }

--- a/Src/StackifyLib/Internal/Auth/Claims/AppClaimsBuilderFullFramework.cs
+++ b/Src/StackifyLib/Internal/Auth/Claims/AppClaimsBuilderFullFramework.cs
@@ -194,7 +194,7 @@ namespace StackifyLib.Internal.Auth.Claims
         {
             var machineName = Environment.MachineName;
 
-            if (Config.IsEc2 == true || (machineName.StartsWith("EC2") && machineName.Contains("-")))
+            if (Config.IsEc2 == null || Config.IsEc2 == true || (machineName.StartsWith("EC2") && machineName.Contains("-")))
             {
                 AppClaims.DeviceName = await GetEC2InstanceId() ?? machineName;
             }

--- a/Src/StackifyLib/Internal/Auth/Claims/AppClaimsBuilderFullFramework.cs
+++ b/Src/StackifyLib/Internal/Auth/Claims/AppClaimsBuilderFullFramework.cs
@@ -190,24 +190,10 @@ namespace StackifyLib.Internal.Auth.Claims
             }
         }
 
-        private async Task SetDeviceName()
-        {
-            var machineName = Environment.MachineName;
-
-            if (Config.IsEc2 == null || Config.IsEc2 == true || (machineName.StartsWith("EC2") && machineName.Contains("-")))
-            {
-                AppClaims.DeviceName = await GetEC2InstanceId() ?? machineName;
-            }
-            else
-            {
-                AppClaims.DeviceName = machineName;
-            }
-        }
-
         /// <summary>
         /// Get the EC2 Instance name if it exists else null
         /// </summary>
-        private static async Task<string> GetEC2InstanceId()
+        protected override Task<string> GetEC2InstanceId()
         {
             try
             {
@@ -225,7 +211,8 @@ namespace StackifyLib.Internal.Auth.Claims
                             using (var reader = new StreamReader(responseStream, encoding))
                             {
                                 var id = reader.ReadToEnd();
-                                return string.IsNullOrWhiteSpace(id) ? null : id;
+                                var r = string.IsNullOrWhiteSpace(id) ? null : id;
+                                return Task.FromResult(r);
                             }
                         }
                     }
@@ -234,7 +221,16 @@ namespace StackifyLib.Internal.Auth.Claims
             catch // if not in aws this will timeout
             { }
 
-            return null;
+            return Task.FromResult<string>(null);
+        }
+
+        /// <summary>
+        /// Get the current machine name
+        /// </summary>
+        protected override string GetMachineName()
+        {
+            var machineName = Environment.MachineName;
+            return machineName;
         }
 
         private void SetClaimsFromAppDomain()

--- a/Src/StackifyLib/Internal/Auth/Claims/AppClaimsBuilderFullFramework.cs
+++ b/Src/StackifyLib/Internal/Auth/Claims/AppClaimsBuilderFullFramework.cs
@@ -51,8 +51,8 @@ namespace StackifyLib.Internal.Auth.Claims
         private void SetWebAppId()
         {
             IsWebRequest = AppDomain.CurrentDomain.FriendlyName.Contains("W3SVC");
-            
-            if(IsWebRequest == false) 
+
+            if (IsWebRequest == false)
                 return;
 
             //regex test cases
@@ -159,7 +159,7 @@ namespace StackifyLib.Internal.Auth.Claims
         {
             if (Environment.UserInteractive || !AppDomain.CurrentDomain.FriendlyName.Contains("W3SVC"))
                 return;
-            
+
             try
             {
                 var query = $"select DisplayName from Win32_Service WHERE ProcessID='{Process.GetCurrentProcess().Id}'";
@@ -187,12 +187,21 @@ namespace StackifyLib.Internal.Auth.Claims
             catch (Exception ex)
             {
                 StackifyAPILogger.Log("Unable to get windows service name\r\n" + ex.ToString(), true);
-            }            
+            }
         }
 
         private async Task SetDeviceName()
         {
-            AppClaims.DeviceName = await GetEC2InstanceId() ?? Environment.MachineName;
+            var machineName = Environment.MachineName;
+
+            if (Config.IsEc2 == true || (machineName.StartsWith("EC2") && machineName.Contains("-")))
+            {
+                AppClaims.DeviceName = await GetEC2InstanceId() ?? machineName;
+            }
+            else
+            {
+                AppClaims.DeviceName = machineName;
+            }
         }
 
         /// <summary>

--- a/Src/StackifyLib/Internal/Auth/Claims/AppClaimsBuilderStandard.cs
+++ b/Src/StackifyLib/Internal/Auth/Claims/AppClaimsBuilderStandard.cs
@@ -21,8 +21,16 @@ namespace StackifyLib.Internal.Auth.Claims
 
         private async Task SetDeviceName()
         {
-            AppClaims.DeviceName = await GetEC2InstanceId()
-                ?? Process.GetCurrentProcess().MachineName;
+            var machineName = Process.GetCurrentProcess().MachineName;
+
+            if (Config.IsEc2 == true || (machineName.StartsWith("EC2") && machineName.Contains("-")))
+            {
+                AppClaims.DeviceName = await GetEC2InstanceId() ?? machineName;
+            }
+            else
+            {
+                AppClaims.DeviceName = machineName;
+            }
         }
 
         /// <summary>

--- a/Src/StackifyLib/Internal/Auth/Claims/AppClaimsBuilderStandard.cs
+++ b/Src/StackifyLib/Internal/Auth/Claims/AppClaimsBuilderStandard.cs
@@ -19,24 +19,10 @@ namespace StackifyLib.Internal.Auth.Claims
             AppClaims.AppLocation = AppContext.BaseDirectory;
         }
 
-        private async Task SetDeviceName()
-        {
-            var machineName = Process.GetCurrentProcess().MachineName;
-
-            if (Config.IsEc2 == null || Config.IsEc2 == true || (machineName.StartsWith("EC2") && machineName.Contains("-")))
-            {
-                AppClaims.DeviceName = await GetEC2InstanceId() ?? machineName;
-            }
-            else
-            {
-                AppClaims.DeviceName = machineName;
-            }
-        }
-
-        /// <summary>
+         /// <summary>
         /// Get the EC2 Instance name if it exists else null
         /// </summary>
-        private static async Task<string> GetEC2InstanceId()
+        protected override async Task<string> GetEC2InstanceId()
         {
             try
             {
@@ -59,6 +45,15 @@ namespace StackifyLib.Internal.Auth.Claims
             { }
 
             return null;
+        }
+
+        /// <summary>
+        /// Get the current machine name
+        /// </summary>
+        protected override string GetMachineName()
+        {
+            var machineName = Process.GetCurrentProcess().MachineName;
+            return machineName;
         }
     }
 }

--- a/Src/StackifyLib/Internal/Auth/Claims/AppClaimsBuilderStandard.cs
+++ b/Src/StackifyLib/Internal/Auth/Claims/AppClaimsBuilderStandard.cs
@@ -23,7 +23,7 @@ namespace StackifyLib.Internal.Auth.Claims
         {
             var machineName = Process.GetCurrentProcess().MachineName;
 
-            if (Config.IsEc2 == true || (machineName.StartsWith("EC2") && machineName.Contains("-")))
+            if (Config.IsEc2 == null || Config.IsEc2 == true || (machineName.StartsWith("EC2") && machineName.Contains("-")))
             {
                 AppClaims.DeviceName = await GetEC2InstanceId() ?? machineName;
             }


### PR DESCRIPTION
…local EC2 endpoint

* GetDeviceName now checks config of IsEC2 (if set short-circuits everything) and machine name (must be "EC2%-%" to trigger call) before making any endpoint calls
* If logic fails for edge-cases the addition of Stackify.IsEC2 = true in AppSettings will workaround