### PR TITLE
RT-613: StackifyLib - Nlog - Wrong server name on .net core

### DIFF
--- a/Src/StackifyLib/Models/EnvironmentDetail.cs
+++ b/Src/StackifyLib/Models/EnvironmentDetail.cs
@@ -189,7 +189,7 @@ namespace StackifyLib.Models
 #else
         public static string GetDeviceName()
         {
-            var deviceName = Process.GetCurrentProcess().MachineName;
+            var deviceName = Environment.MachineName;
             var isDefaultDeviceNameEc2 = IsEc2MachineName(deviceName);
 
             if (Config.IsEc2 == null || Config.IsEc2 == true || isDefaultDeviceNameEc2)


### PR DESCRIPTION
fixes #63 

https://stackoverflow.com/a/43961817

https://github.com/NLog/NLog/issues/1523