### PR TITLE
RT-2393 StackifyLib overcalling AWS check

### DIFF
--- a/Src/StackifyLib/Internal/Logs/LogClient.cs
+++ b/Src/StackifyLib/Internal/Logs/LogClient.cs
@@ -250,7 +250,7 @@ namespace StackifyLib.Internal.Logs
                 }
             }
 
-            var env = EnvironmentDetail.Get(false);
+            var env = EnvironmentDetail.Get();
 
             //We use whatever the identity stuff says, otherwise we use the azure instance name and fall back to the machine name
             if (string.IsNullOrEmpty(group.ServerName))

--- a/Src/StackifyLib/StackifyError.cs
+++ b/Src/StackifyLib/StackifyError.cs
@@ -114,7 +114,7 @@ namespace StackifyLib
             TimeSpan ts = DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1, 0, 0, 0, 0));
             OccurredEpochMillis = (long)ts.TotalMilliseconds;
 
-            EnvironmentDetail = EnvironmentDetail.Get(false);
+            EnvironmentDetail = EnvironmentDetail.Get();
             ServerVariables = new Dictionary<string, string>();
 
 #if NETFULL

--- a/Src/StackifyLib/Utils/HttpClient.cs
+++ b/Src/StackifyLib/Utils/HttpClient.cs
@@ -301,7 +301,7 @@ namespace StackifyLib.Utils
                     return false;
                 }
                 StackifyAPILogger.Log("Calling to Identify App");
-                EnvironmentDetail env = EnvironmentDetail.Get(true);
+                EnvironmentDetail env = EnvironmentDetail.Get();
                 string jsonData = JsonConvert.SerializeObject(env, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
 
                 var response =


### PR DESCRIPTION
Use static Http Client for call to avoid connection pool exhaustion. Only check if we are in AWS once at startup.