### PR TITLE
Custom layout renderer to support nlog target async for HttpContext

### DIFF
--- a/Src/NLog.Targets.Stackify/NLog.Targets.Stackify.csproj
+++ b/Src/NLog.Targets.Stackify/NLog.Targets.Stackify.csproj
@@ -22,10 +22,12 @@
     <RepositoryUrl>https://github.com/stackify/stackify-api-dotnet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\StackifyLib\StackifyLib.csproj" />
     <PackageReference Include="NLog" Version="4.5.0" />
+    <PackageReference Include="NLog.Config" Version="4.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
@@ -35,5 +37,17 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net461' ">
     <DefineConstants>NETFULL</DefineConstants>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Routing" />
+    <PackageReference Include="NLog.Web" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.1.1" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="4.5.0" />
+  </ItemGroup>
 
 </Project>

--- a/Src/NLog.Targets.Stackify/StackifyHttpLayoutRenderer.cs
+++ b/Src/NLog.Targets.Stackify/StackifyHttpLayoutRenderer.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using NLog.Config;
+using NLog.LayoutRenderers;
+using NLog.Web.LayoutRenderers;
+using StackifyLib.Models;
+using Newtonsoft.Json;
+
+namespace NLog.Targets.Stackify
+{
+    [LayoutRenderer("stackify-http")]
+    public class StackifyHttpLayoutRenderer : AspNetLayoutRendererBase
+    {
+        protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
+        {
+            var httpRequest = HttpContextAccessor.HttpContext;
+            if (httpRequest != null)
+            {
+#if NETFULL
+                WebRequestDetail webRequest = new WebRequestDetail();
+                webRequest.Load(httpRequest);
+
+                string result = JsonConvert.SerializeObject(webRequest);
+                builder.Append(result);
+#endif
+            }
+        }
+    }
+}

--- a/Src/NLog.Targets.Stackify/StackifyTarget.cs
+++ b/Src/NLog.Targets.Stackify/StackifyTarget.cs
@@ -268,6 +268,18 @@ namespace NLog.Targets.Stackify
                 stackifyError = StackifyError.New(stringException);
             }
 
+            if(stackifyError.WebRequestDetail == null && contextProperties.ContainsKey("stackifyhttp"))
+            {
+#if NETFULL
+                string hctx = contextProperties["stackifyhttp"]?.ToString();
+                if (!string.IsNullOrEmpty(hctx))
+                {
+                    var webRequestDetail = Newtonsoft.Json.JsonConvert.DeserializeObject<WebRequestDetail>(hctx);
+                    stackifyError.WebRequestDetail = webRequestDetail;
+                }
+#endif
+            }
+
             if (stackifyError != null && !StackifyError.IgnoreError(stackifyError) && _logClient.ErrorShouldBeSent(stackifyError))
             {
                 stackifyError.SetAdditionalMessage(loggingEvent.FormattedMessage);

--- a/Src/StackifyLib/Internal/Logs/LogQueue.cs
+++ b/Src/StackifyLib/Internal/Logs/LogQueue.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 #if NETFULL
 using System.Runtime.Remoting.Messaging;
 using StackifyLib.Web;
+using System.Web;
 #endif
 
 namespace StackifyLib.Internal.Logs
@@ -158,7 +159,7 @@ namespace StackifyLib.Internal.Logs
                     }
                     else
                     {
-                        var resolver = new RouteResolver(context);
+                        var resolver = new RouteResolver(new HttpContextWrapper(context));
 
                         var route = resolver.GetRoute();
 

--- a/Src/StackifyLib/Models/WebRequestDetail.cs
+++ b/Src/StackifyLib/Models/WebRequestDetail.cs
@@ -9,7 +9,6 @@ using Newtonsoft.Json;
 
 #if NETFULL
 using System.Web;
-using System.Web.Routing;
 using StackifyLib.Web;
 
 #endif
@@ -25,6 +24,12 @@ namespace StackifyLib.Models
         public static event SetWebRequestDetailEventHandler SetWebRequestDetail;
 
         private StackifyError _Error;
+
+        public WebRequestDetail()
+        {
+
+        }
+
         public WebRequestDetail(StackifyError error)
         {
             _Error = error;
@@ -32,7 +37,7 @@ namespace StackifyLib.Models
 #if NETFULL
             if (System.Web.HttpContext.Current != null)
             {
-                Load(System.Web.HttpContext.Current);
+                Load(new HttpContextWrapper(System.Web.HttpContext.Current));
             }
 #endif
 
@@ -93,12 +98,12 @@ namespace StackifyLib.Models
 
 
 #if NETFULL
-        private void Load(HttpContext context)
+        public void Load(HttpContextBase context)
         {
             if (context == null || context.Request == null)
                 return;
 
-            HttpRequest request = context.Request;
+            HttpRequestBase request = context.Request;
 
             try
             {
@@ -248,16 +253,16 @@ namespace StackifyLib.Models
         }
 
 #if NETFULL
-        internal static Dictionary<string, string> ToKeyValues(HttpCookieCollection collection, List<string> goodKeys, List<string> badKeys)
+        internal static Dictionary<string, string> ToKeyValues(HttpSessionStateBase collection, List<string> goodKeys, List<string> badKeys)
         {
-            var keys = collection.AllKeys;
+            var keys = collection.Keys;
             var items = new Dictionary<string, string>();
 
             foreach (string key in keys)
             {
                 try
                 {
-                    HttpCookie cookie = collection[key];
+                    HttpCookie cookie = collection[key] as HttpCookie;
 
                     if (cookie != null &&  !string.IsNullOrWhiteSpace(cookie.Value) && !items.ContainsKey(key))
                     {
@@ -272,6 +277,32 @@ namespace StackifyLib.Models
 
             return items;
         }
+
+        internal static Dictionary<string, string> ToKeyValues(HttpCookieCollection collection, List<string> goodKeys, List<string> badKeys)
+        {
+            var keys = collection.Keys;
+            var items = new Dictionary<string, string>();
+
+            foreach (string key in keys)
+            {
+                try
+                {
+                    HttpCookie cookie = collection[key] as HttpCookie;
+
+                    if (cookie != null && !string.IsNullOrWhiteSpace(cookie.Value) && !items.ContainsKey(key))
+                    {
+                        AddKey(key, cookie.Value, items, goodKeys, badKeys);
+                    }
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+
+            return items;
+        }
+
 
         internal static Dictionary<string, string> ToKeyValues(NameValueCollection collection, List<string> goodKeys, List<string> badKeys)
         {

--- a/Src/StackifyLib/Web/RouteResolver.cs
+++ b/Src/StackifyLib/Web/RouteResolver.cs
@@ -42,16 +42,16 @@ namespace StackifyLib.Web
             }
         }
 
-        private HttpContext _Context = null;
+        private HttpContextBase _Context = null;
 
         Route _Route = new Route();
 
         public RouteResolver()
-            : this(System.Web.HttpContext.Current)
+            : this(new HttpContextWrapper(System.Web.HttpContext.Current))
         {
         }
 
-        public RouteResolver(HttpContext context)
+        public RouteResolver(HttpContextBase context)
         {
             _Context = context;
 
@@ -139,11 +139,9 @@ namespace StackifyLib.Web
             {
                 if (_Context == null) return route;
 
-                var wrapper = new HttpContextWrapper(_Context);
+                if (_Context == null || RouteTable.Routes == null) return route;
 
-                if (wrapper == null || RouteTable.Routes == null) return route;
-
-                var routeData = RouteTable.Routes.GetRouteData(wrapper);
+                var routeData = RouteTable.Routes.GetRouteData(_Context);
 
                 if (routeData != null && routeData.Values != null && routeData.Values.Any())
                 {


### PR DESCRIPTION
-Added a custom layout renderer to capture HttpContext to support nlog target async
-Changed the HttpContext to HttpContextBase to support fullframework and .net core
-Usage: <contextproperty name="stackifyhttp" layout="${stackify-http}" />

Sample:
 <nlog>
    <extensions>
      <add assembly="NLog.Targets.Stackify" />
    </extensions>
    <targets async="true">
      <target type="StackifyTarget" name="stackify" logAllParams="true" >
        <contextproperty name="stackifyhttp" layout="${stackify-http}" />
      </target>
    </targets>
    <rules>
      <logger name="*" minlevel="Debug" writeTo="stackify" />
    </rules>
  </nlog>
