### PR TITLE
Stackify-http layout renderer transferred to a new project 

### DIFF
--- a/Src/NLog.Targets.Stackify/StackifyTarget.cs
+++ b/Src/NLog.Targets.Stackify/StackifyTarget.cs
@@ -271,15 +271,12 @@ namespace NLog.Targets.Stackify
                 stackifyError = StackifyError.New(stringException);
             }
 
-            if(stackifyError.WebRequestDetail == null && contextProperties.ContainsKey("stackifyhttp"))
+            string stackifyHttp = StackifyHttpRequestInfo.Render(loggingEvent);
+            if (stackifyError.WebRequestDetail == null && !String.IsNullOrEmpty(stackifyHttp))
             {
 #if NETFULL
-                string hctx = contextProperties["stackifyhttp"]?.ToString();
-                if (!string.IsNullOrEmpty(hctx))
-                {
-                    var webRequestDetail = Newtonsoft.Json.JsonConvert.DeserializeObject<WebRequestDetail>(hctx);
-                    stackifyError.WebRequestDetail = webRequestDetail;
-                }
+                var webRequestDetail = Newtonsoft.Json.JsonConvert.DeserializeObject<WebRequestDetail>(stackifyHttp);
+                stackifyError.WebRequestDetail = webRequestDetail;
 #endif
             }
 

--- a/Src/NLog.Targets.Stackify/StackifyTarget.cs
+++ b/Src/NLog.Targets.Stackify/StackifyTarget.cs
@@ -271,13 +271,23 @@ namespace NLog.Targets.Stackify
                 stackifyError = StackifyError.New(stringException);
             }
 
-            string stackifyHttp = StackifyHttpRequestInfo.Render(loggingEvent);
-            if (stackifyError.WebRequestDetail == null && !String.IsNullOrEmpty(stackifyHttp))
+            if (StackifyHttpRequestInfo != null)
             {
+                string stackifyHttp = StackifyHttpRequestInfo.Render(loggingEvent);
+                if (stackifyError.WebRequestDetail == null && !String.IsNullOrEmpty(stackifyHttp))
+                {
 #if NETFULL
-                var webRequestDetail = Newtonsoft.Json.JsonConvert.DeserializeObject<WebRequestDetail>(stackifyHttp);
-                stackifyError.WebRequestDetail = webRequestDetail;
+                    try
+                    {
+                        var webRequestDetail = Newtonsoft.Json.JsonConvert.DeserializeObject<WebRequestDetail>(stackifyHttp);
+                        stackifyError.WebRequestDetail = webRequestDetail;
+                    }
+                    catch (Exception e)
+                    {
+                        InternalLogger.Warn(e, "StackifyHttpRequestInfo: Failed to DeserializeObject");
+                    }
 #endif
+                }
             }
 
             if (stackifyError != null && !StackifyError.IgnoreError(stackifyError) && _logClient.ErrorShouldBeSent(stackifyError))

--- a/Src/NLog.Targets.Stackify/StackifyTarget.cs
+++ b/Src/NLog.Targets.Stackify/StackifyTarget.cs
@@ -9,6 +9,7 @@ using StackifyLib;
 using StackifyLib.Internal.Logs;
 using StackifyLib.Models;
 using StackifyLib.Utils;
+using NLog.Layouts;
 
 namespace NLog.Targets.Stackify
 {
@@ -35,6 +36,8 @@ namespace NLog.Targets.Stackify
 
         [ArrayParameter(typeof(TargetPropertyWithContext), "contextproperty")]
         public override IList<TargetPropertyWithContext> ContextProperties { get; } = new List<TargetPropertyWithContext>();
+
+        public Layout StackifyHttpRequestInfo { get; set; }
 
         public StackifyTarget()
         {

--- a/Src/NLog.Web.Stackify/NLog.Web.Stackify.csproj
+++ b/Src/NLog.Web.Stackify/NLog.Web.Stackify.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyTitle>NLog.Targets.Stackify</AssemblyTitle>
+    <AssemblyTitle>NLog.Web.Stackify</AssemblyTitle>
     <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net40;net45;net461</TargetFrameworks>
-    <AssemblyName>NLog.Targets.Stackify</AssemblyName>
-    <PackageId>NLog.Targets.Stackify</PackageId>
+    <AssemblyName>NLog.Web.Stackify</AssemblyName>
+    <PackageId>NLog.Web.Stackify</PackageId>
     <PackageTags>stackify;errors;logs</PackageTags>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
@@ -22,19 +22,29 @@
     <RepositoryUrl>https://github.com/stackify/stackify-api-dotnet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\StackifyLib\StackifyLib.csproj" />
     <PackageReference Include="NLog" Version="4.5.11" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <DefineConstants>NETCORE</DefineConstants>
   </PropertyGroup>
-
+  
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net461' ">
     <DefineConstants>NETFULL</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Routing" />
+    <PackageReference Include="NLog.Web" Version="4.8.0" />
+  </ItemGroup>
   
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NLog.Web.AspNetCore" Version="4.8.0" />
+  </ItemGroup>
 </Project>

--- a/Src/NLog.Web.Stackify/StackifyHttpLayoutRenderer.cs
+++ b/Src/NLog.Web.Stackify/StackifyHttpLayoutRenderer.cs
@@ -13,11 +13,6 @@ namespace NLog.Web.Stackify
     [ThreadSafe]
     public class StackifyHttpLayoutRenderer : AspNetLayoutRendererBase
     {
-        public StackifyHttpLayoutRenderer()
-        {
-
-        }
-
         protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
         {
             var httpRequest = HttpContextAccessor.HttpContext;

--- a/Src/NLog.Web.Stackify/StackifyHttpLayoutRenderer.cs
+++ b/Src/NLog.Web.Stackify/StackifyHttpLayoutRenderer.cs
@@ -7,11 +7,17 @@ using NLog.Web.LayoutRenderers;
 using StackifyLib.Models;
 using Newtonsoft.Json;
 
-namespace NLog.Targets.Stackify
+namespace NLog.Web.Stackify
 {
     [LayoutRenderer("stackify-http")]
+    [ThreadSafe]
     public class StackifyHttpLayoutRenderer : AspNetLayoutRendererBase
     {
+        public StackifyHttpLayoutRenderer()
+        {
+
+        }
+
         protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
         {
             var httpRequest = HttpContextAccessor.HttpContext;

--- a/Src/StackifyLibCore.sln
+++ b/Src/StackifyLibCore.sln
@@ -31,6 +31,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{CA78
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StackifyLib.UnitTests", "..\test\StackifyLib.UnitTests\StackifyLib.UnitTests.csproj", "{0A9026C3-2A91-4A45-893C-17C6AF006FA0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.Web.Stackify", "NLog.Web.Stackify\NLog.Web.Stackify.csproj", "{647F27AD-13D7-40C2-A7BB-97A5D19CE3D5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -81,6 +83,10 @@ Global
 		{0A9026C3-2A91-4A45-893C-17C6AF006FA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0A9026C3-2A91-4A45-893C-17C6AF006FA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0A9026C3-2A91-4A45-893C-17C6AF006FA0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{647F27AD-13D7-40C2-A7BB-97A5D19CE3D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{647F27AD-13D7-40C2-A7BB-97A5D19CE3D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{647F27AD-13D7-40C2-A7BB-97A5D19CE3D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{647F27AD-13D7-40C2-A7BB-97A5D19CE3D5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -96,6 +102,7 @@ Global
 		{E141CDE4-501C-4533-8A2E-344522B1991E} = {709EEA1C-81B6-4369-AB25-6A03D4BEC75F}
 		{28A61379-B316-480F-B45E-C622C42CAE8D} = {709EEA1C-81B6-4369-AB25-6A03D4BEC75F}
 		{0A9026C3-2A91-4A45-893C-17C6AF006FA0} = {36B13547-8CBC-4985-9495-555500880F1D}
+		{647F27AD-13D7-40C2-A7BB-97A5D19CE3D5} = {709EEA1C-81B6-4369-AB25-6A03D4BEC75F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6AB55A24-BCFF-4641-90E0-7921CAD32F49}

--- a/samples/CoreConsoleApp/CoreConsoleApp.csproj
+++ b/samples/CoreConsoleApp/CoreConsoleApp.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
-    <PackageReference Include="NLog" Version="4.5.0" />
+    <PackageReference Include="NLog" Version="4.5.11" />
     <PackageReference Include="Serilog" Version="2.4.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />

--- a/samples/CoreWebApp/CoreWebApp.csproj
+++ b/samples/CoreWebApp/CoreWebApp.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.2" />
-    <PackageReference Include="NLog" Version="4.5.0" />
+    <PackageReference Include="NLog" Version="4.5.11" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-rc4" />
     <PackageReference Include="Serilog" Version="2.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />


### PR DESCRIPTION
- New custom layout renderer to capture httpcontext is transferred to a new project (NLog.Web.Stackify)
- Removed aspnet, nlog.web, nlog.config in Nlog.Targets.Stackify
- Bumped NLog version to 4.5.11 to support threadsafe and nlog.web 4.8.0
- New property in Nlog.Target.Stackify to get/set serialized httpcontext

NLog config:
`<nlog>
    <extensions>
      <add assembly="NLog.Targets.Stackify" />
      <add assembly="NLog.Web.Stackify" />
    </extensions>
    <targets async="true">
      <target type="StackifyTarget" name="stackify" logAllParams="true" stackifyHttpRequestInfo="${stackify-http}" />
    </targets>
    <rules>
      <logger name="*" minlevel="Debug" writeTo="stackify" />
    </rules>
  </nlog>`