### PR TITLE
Prevent serialization of large objects passed in ASP.Net Core Logging

### DIFF
--- a/Src/NLog.Targets.Stackify/NLog.Targets.Stackify.csproj
+++ b/Src/NLog.Targets.Stackify/NLog.Targets.Stackify.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>2.1.6</Version>
+    <Version>2.1.7</Version>
     <PackageLicenseUrl>https://github.com/stackify/stackify-api-dotnet/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/stackify/stackify-api-dotnet</PackageProjectUrl>
     <PackageIconUrl>https://stackify.com/wp-content/uploads/2017/02/stk.png</PackageIconUrl>

--- a/Src/StackifyLib.AspNetCore/StackifyLib.AspNetCore.csproj
+++ b/Src/StackifyLib.AspNetCore/StackifyLib.AspNetCore.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.1.5</Version>
+    <Version>2.1.6</Version>
     <Description>StackifyLib.AspNetCore</Description>
     <PackageLicenseUrl>https://github.com/stackify/stackify-api-dotnet/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/stackify/stackify-api-dotnet</PackageProjectUrl>

--- a/Src/StackifyLib/StackifyLib.csproj
+++ b/Src/StackifyLib/StackifyLib.csproj
@@ -13,7 +13,7 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <Version>2.1.6</Version>
+    <Version>2.1.8</Version>
     <Authors>StackifyLib</Authors>
     <PackageProjectUrl>https://github.com/stackify/stackify-api-dotnet</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/stackify/stackify-api-dotnet/blob/master/LICENSE</PackageLicenseUrl>

--- a/Src/StackifyLib/Utils/HelperFunctions.cs
+++ b/Src/StackifyLib/Utils/HelperFunctions.cs
@@ -18,7 +18,7 @@ namespace StackifyLib.Utils
             ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
             Converters = new List<JsonConverter>() {
                     new ToStringConverter("Module", typeof(Module)),
-                    new ToStringConverter("Method", typeof(MethodBase)),
+                    new ToStringConverter("Method", typeof(MemberInfo)),
                     new ToStringConverter("Assembly", typeof(Assembly)),
             }
         };


### PR DESCRIPTION
Handle cases where ASP.Net Core internal logging passes Assembly/Method information for log statements to prevent uploading large messages