### PR TITLE
NLog.Targets.Stackify - Removed direct PackageReference Newtonsoft.Json

### DIFF
--- a/Src/NLog.Targets.Stackify/NLog.Targets.Stackify.csproj
+++ b/Src/NLog.Targets.Stackify/NLog.Targets.Stackify.csproj
@@ -27,7 +27,6 @@
   <ItemGroup>
     <ProjectReference Include="..\StackifyLib\StackifyLib.csproj" />
     <PackageReference Include="NLog" Version="4.5.11" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/Src/NLog.Web.Stackify/NLog.Web.Stackify.csproj
+++ b/Src/NLog.Web.Stackify/NLog.Web.Stackify.csproj
@@ -26,7 +26,6 @@
   <ItemGroup>
     <ProjectReference Include="..\StackifyLib\StackifyLib.csproj" />
     <PackageReference Include="NLog" Version="4.5.11" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">


### PR DESCRIPTION
Already a transitive dependency from StackifyLib:

https://www.nuget.org/packages/StackifyLib/

Aligns the NLog-nuget-package with Log4net and Serilog