### PR TITLE
#129 & DoTNET-117

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ static void StackifyAPILogger_OnLogMessage(string data)
 }
 ```
 
+## Additional Settings
+
+These settings are available to further customize what information is captured and transmitted to Stackify.
+
+```xml
+<appSettings>
+       <add key="Stackify.CaptureErrorHeaders" value="true" />
+       <add key="Stackify.CaptureServerVariables" value="false" />
+       <add key="Stackify.CaptureSessionVariables" value="false" />
+       <add key="Stackify.CaptureErrorCookies" value="false" />
+       <add key="Stackify.CaptureErrorUserName" value="true" />
+       <add key="Stackify.CaptureErrorPostdata" value="false" />
+</appSettings>
+```
+
 
 ## Errors and Logs
 

--- a/Src/NLog.Targets.Stackify/Properties/AssemblyInfo.cs
+++ b/Src/NLog.Targets.Stackify/Properties/AssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyKeyFileAttribute("..\\StackifyLib\\Netreo.snk")]
+//[assembly: AssemblyKeyFile("..\\StackifyLib\\Netreo.snk")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Src/StackifyLib.AspNetCore/Properties/AssemblyInfo.cs
+++ b/Src/StackifyLib.AspNetCore/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Stackify")]
 [assembly: AssemblyProduct("StackifyLib.AspNetCore")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyKeyFileAttribute("..\\StackifyLib\\Netreo.snk")]
+//[assembly: AssemblyKeyFile("..\\StackifyLib\\Netreo.snk")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Src/StackifyLib.CoreLogger/Properties/AssemblyInfo.cs
+++ b/Src/StackifyLib.CoreLogger/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Stackify")]
 [assembly: AssemblyProduct("StackifyLib.CoreLogger")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyKeyFileAttribute("..\\StackifyLib\\Netreo.snk")]
+//[assembly: AssemblyKeyFile("..\\StackifyLib\\Netreo.snk")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Src/StackifyLib.ELMAH/Properties/AssemblyInfo.cs
+++ b/Src/StackifyLib.ELMAH/Properties/AssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyKeyFileAttribute("..\\StackifyLib\\Netreo.snk")]
+//[assembly: AssemblyKeyFile("..\\StackifyLib\\Netreo.snk")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Src/StackifyLib.StackifyTraceListener/Properties/AssemblyInfo.cs
+++ b/Src/StackifyLib.StackifyTraceListener/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Stackify")]
 [assembly: AssemblyProduct("StackifyLib.StackifyTraceListener")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyKeyFileAttribute("..\\StackifyLib\\Netreo.snk")]
+//[assembly: AssemblyKeyFile("..\\StackifyLib\\Netreo.snk")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Src/StackifyLib.log4net/Properties/AssemblyInfo.cs
+++ b/Src/StackifyLib.log4net/Properties/AssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyKeyFileAttribute("..\\StackifyLib\\Netreo.snk")]
+//[assembly: AssemblyKeyFile("..\\StackifyLib\\Netreo.snk")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Src/StackifyLib/Config.cs
+++ b/Src/StackifyLib/Config.cs
@@ -62,6 +62,10 @@ namespace StackifyLib
 
                 CaptureErrorCookies = Get("Stackify.CaptureErrorCookies", bool.FalseString).Equals(bool.TrueString, StringComparison.CurrentCultureIgnoreCase);
 
+                CaptureErrorUserName = Get("Stackify.CaptureErrorUserName", bool.TrueString).Equals(bool.TrueString, StringComparison.CurrentCultureIgnoreCase);
+
+                CaptureErrorPostdata = Get("Stackify.CaptureErrorPostdata", bool.FalseString).Equals(bool.TrueString, StringComparison.CurrentCultureIgnoreCase);
+
                 ApiKey = Get("Stackify.ApiKey", ApiKey ?? string.Empty);
 
                 AppName = Get("Stackify.AppName", AppName ?? string.Empty);
@@ -183,21 +187,14 @@ namespace StackifyLib
         public static bool CaptureErrorPostdata { get; set; }
         public static bool CaptureErrorHeaders { get; set; } = true;
         public static bool CaptureErrorCookies { get; set; }
-
+        public static bool CaptureErrorUserName { get; set; } = true;
         public static string CaptureErrorSessionWhitelist { get; set; }
-
         public static string CaptureErrorHeadersWhitelist { get; set; }
-
         public static string CaptureErrorHeadersBlacklist { get; set; } = "cookie,authorization";
-
         public static string CaptureErrorCookiesWhitelist { get; set; }
-
         public static string CaptureErrorCookiesBlacklist { get; set; } = ".ASPXAUTH";
-
         public static int Ec2InstanceMetadataUpdateThresholdMinutes { get; set; } = 60;
-
         public static bool? IsEc2 { get; set; }
-
         public static bool? ApiLog { get; set; }
 
         public static int LoggingJsonMaxFields { get; set; } = 50;

--- a/Src/StackifyLib/Properties/AssemblyInfo.cs
+++ b/Src/StackifyLib/Properties/AssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © 2018-2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyKeyFileAttribute("Netreo.snk")]
+//[assembly: AssemblyKeyFile("Netreo.snk")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Src/StackifyLib/StackifyError.cs
+++ b/Src/StackifyLib/StackifyError.cs
@@ -153,7 +153,7 @@ namespace StackifyLib
                 {
                     WebRequestDetail = new WebRequestDetail(this);
 
-                    if (HttpContext.Current.User != null && HttpContext.Current.User.Identity != null)
+                    if (Config.CaptureErrorUserName && HttpContext.Current.User != null && HttpContext.Current.User.Identity != null)
                     {
                         UserName = HttpContext.Current.User.Identity.Name;
                     }
@@ -163,7 +163,7 @@ namespace StackifyLib
 #else
             WebRequestDetail = new WebRequestDetail(this);
 #endif
-
+            
             //Fire event
             OnCaptureDetail?.Invoke(this);
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,16 @@ steps:
     inputs:
       targetType: inline
       script: >
-        (Get-Content -path Src\StackifyLib\StackifyLib.csproj -Raw) -replace '<PackageId>StackifyLib</PackageId>','<PackageId>StackifyLib.signed</PackageId>' | Set-Content -Path Src\StackifyLib\StackifyLib.csproj
+        (Get-Content -path Src\StackifyLib\StackifyLib.csproj -Raw) -replace '<PackageId>StackifyLib</PackageId>','<PackageId>StackifyLib.signed</PackageId>' | Set-Content -Path Src\StackifyLib\StackifyLib.csproj -Encoding utf8
+  
+  # note: the signing attribute here is commented out so we can build locally
+  - powershell: |
+      $filename = Get-ChildItem ".\src\*\AssemblyInfo.cs" -Recurse
+      $filename | %{
+         (gc $_) -replace ([regex]::Escape("//[assembly: AssemblyKeyFile")), "[assembly: AssemblyKeyFile" | Set-Content $_.FullName -Encoding utf8
+      }
+    displayName: Uncoment signing attribute
+  
   - task: PowerShell@2
     displayName: 'Setup Code Signing'
     inputs:


### PR DESCRIPTION
This contains the fix for #129 to allow for not capturing the username from web error captures. 

Also contains an update to allow local devs to build the project without the Netreo.snk available.