### PR TITLE
(IMPROVEMENT)(DOTNET-199) - Add NLog 5.x as dependency for NLog.Targets.Stackify

### DIFF
--- a/Src/NLog.Targets.Stackify/NLog.Targets.Stackify.csproj
+++ b/Src/NLog.Targets.Stackify/NLog.Targets.Stackify.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.7.15" PrivateAssets="all" />
+    <PackageReference Include="NLog" Version="5.0.0" />
     <PackageReference Include="StackifyLib" Version="2.2.16" />
   </ItemGroup>
 

--- a/samples/CoreConsoleApp/CoreConsoleApp.csproj
+++ b/samples/CoreConsoleApp/CoreConsoleApp.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Src\NLog.Targets.Stackify\NLog.Targets.Stackify.csproj" />
     <ProjectReference Include="..\..\Src\StackifyLib.log4net\StackifyLib.log4net.csproj" />
     <ProjectReference Include="..\..\Src\StackifyLib\StackifyLib.csproj" />
   </ItemGroup>
@@ -22,7 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
-    <PackageReference Include="NLog" Version="4.5.11" />
+    <PackageReference Include="NLog" Version="4.7.15" />
+    <PackageReference Include="NLog.Targets.Stackify" Version="2.2.0" />
     <PackageReference Include="Serilog" Version="2.4.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />

--- a/samples/CoreWebApp/CoreWebApp.csproj
+++ b/samples/CoreWebApp/CoreWebApp.csproj
@@ -16,7 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Src\NLog.Targets.Stackify\NLog.Targets.Stackify.csproj" />
     <ProjectReference Include="..\..\Src\StackifyLib.AspNetCore\StackifyLib.AspNetCore.csproj" />
     <ProjectReference Include="..\..\Src\StackifyLib.CoreLogger\StackifyLib.CoreLogger.csproj" />
     <ProjectReference Include="..\..\Src\StackifyLib.log4net\StackifyLib.log4net.csproj" />
@@ -31,7 +30,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.2" />
-    <PackageReference Include="NLog" Version="4.5.11" />
+    <PackageReference Include="NLog" Version="4.7.15" />
+    <PackageReference Include="NLog.Targets.Stackify" Version="2.2.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-rc4" />
     <PackageReference Include="Serilog" Version="2.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />


### PR DESCRIPTION
Overview:
- We have issues with assembly exceptions when using NLog 5.x on our application

Solution:
- Make the dependency use NLog 5.x
