### PR TITLE
(BUGFIX)(DOTNET-202) - Revert content-length on GZip post

### DIFF
--- a/Src/StackifyLib/Utils/HttpClient.cs
+++ b/Src/StackifyLib/Utils/HttpClient.cs
@@ -638,7 +638,6 @@ namespace StackifyLib.Utils
                 byte[] payload = Encoding.UTF8.GetBytes(jsonData);
 
 #if NETFULL
-                request.ContentLength = payload.Length;
                 using (Stream postStream = request.GetRequestStream())
 #else
                 using (Stream postStream = request.GetRequestStreamAsync().GetAwaiter().GetResult())


### PR DESCRIPTION
**Overview:**

- Setting Content-Length on gzip terminates the request early

**Solution:**

- Revert the fix on adding the content-length